### PR TITLE
Fix logo size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -31,6 +31,14 @@ body {
     -webkit-font-smoothing: antialiased;
 }
 
+/* Logo Styles */
+.main-logo {
+    max-width: 200px;
+    height: auto;
+    display: block;
+    margin: 2rem auto;
+}
+
 /* Layout Components */
 .sidebar-container {
     width: 288px;
@@ -190,6 +198,11 @@ body {
         width: 40px;
         height: 40px;
     }
+
+    .main-logo {
+        max-width: 150px;
+        margin: 1.5rem auto;
+    }
 }
 
 @media (max-width: 480px) {
@@ -199,6 +212,11 @@ body {
     
     .card {
         padding: 16px;
+    }
+
+    .main-logo {
+        max-width: 120px;
+        margin: 1rem auto;
     }
 }
 


### PR DESCRIPTION
Added CSS styles to control the logo size:
- Set max-width to 200px for desktop
- Added responsive sizes for tablets (150px) and mobile (120px)
- Added proper margins and display properties
- Maintained aspect ratio with height: auto